### PR TITLE
Add skip buttons 20240803

### DIFF
--- a/resources/data/embed.html
+++ b/resources/data/embed.html
@@ -70,7 +70,6 @@
   else if (video.canPlayType('application/vnd.apple.mpegurl')) {
     player.src = videoSrc;
   }
-
   
   function toggleAudio(x) {
     var elements=document.getElementsByClassName("audioButton");

--- a/resources/data/embed.html
+++ b/resources/data/embed.html
@@ -11,7 +11,9 @@
 <video id="video" controls></video>
 <audio id="audio" controls></audio>
 <span id="audioSpan"></span>
-<button onclick="history.back()">Go Back</button>
+<script>function changeTime(x){video.currentTime+=x}</script>
+<span id="seekSpan"><p>Skip: <button onclick="changeTime(-30)">- 30 s</button> <button onclick="changeTime(-10)">- 10 s</button> <button onclick="changeTime(10)">+ 10 s</button> <button onclick="changeTime(30)">+ 30 s</button> <button onclick="changeTime(90)">+ 90 s</button>  <button onclick="changeTime(120)">+ 120 s</button></span>
+<p><button onclick="history.back()">Go Back</button></p>
 <script>
   element = 'video'
   hls_config = {}
@@ -68,6 +70,7 @@
   else if (video.canPlayType('application/vnd.apple.mpegurl')) {
     player.src = videoSrc;
   }
+
   
   function toggleAudio(x) {
     var elements=document.getElementsByClassName("audioButton");


### PR DESCRIPTION
This is an attempt to add skip buttons to fast forward and rewind, similar to what is done in mlbserver. I'm not a front end person, I don't use Kodi, and I obviously don't know your roadmap, so no offense if you don't want to take on this code. If this doesn't look useful, please just consider it a vote in favor of adding back similar buttons at some point in the future. I did test it with chrome on a macbook running OSX, but not on any other devices.
<img width="710" alt="Screenshot 2024-08-03 at 21 59 55" src="https://github.com/user-attachments/assets/f29ad548-9836-45e3-9b8e-7b28a51a9749">

